### PR TITLE
Prevents the use of actions/setup-java@v1 and adopt /adopt-hotspot (openjdk) distributions.

### DIFF
--- a/pkg/rulesConfig/defaultRules/github/12-prevent-action-setup-java-v1.json
+++ b/pkg/rulesConfig/defaultRules/github/12-prevent-action-setup-java-v1.json
@@ -2,7 +2,7 @@
 	"description": "Prevent use of action/setup-java@v1.",
 	"failureMessage": "action/setup-java@v1 is used on the workflow. action/setup-java@v1 uses a java distribution that is out of support (AdoptOpenJDK) by default, please use action/setup-java@v2+ and avoid the use of adopt/adopt-host distributions.",
 	"uniqueId": 12,
-	"enableByDefault": true,
+	"enabledByDefault": true,
 	"schema": {
 		"type": "object",
 		"additionalProperties": {

--- a/pkg/rulesConfig/defaultRules/github/12-prevent-action-setup-java-v1.json
+++ b/pkg/rulesConfig/defaultRules/github/12-prevent-action-setup-java-v1.json
@@ -1,6 +1,6 @@
 {
 	"description": "Prevent use of action/setup-java@v1.",
-	"failureMessage": "action/setup-java@v1 is used on the workflow.",
+	"failureMessage": "action/setup-java@v1 is used on the workflow. action/setup-java@v1 uses a java distribution that is out of support (AdoptOpenJDK) by default, please use action/setup-java@v2+ and avoid the use of adopt/adopt-host distributions.",
 	"uniqueId": 12,
 	"enableByDefault": true,
 	"schema": {

--- a/pkg/rulesConfig/defaultRules/github/12-prevent-action-setup-java-v1.json
+++ b/pkg/rulesConfig/defaultRules/github/12-prevent-action-setup-java-v1.json
@@ -1,0 +1,54 @@
+{
+	"description": "Prevent use of action/setup-java@v1.",
+	"failureMessage": "action/setup-java@v1 is used on the workflow.",
+	"uniqueId": 12,
+	"enableByDefault": true,
+	"schema": {
+		"type": "object",
+		"additionalProperties": {
+			"type": "object",
+			"properties": {
+				"repositories": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "object",
+						"properties": {
+							"github-actions-workflows": {
+								"type": "object",
+								"additionalProperties": {
+									"properties": {
+										"content": {
+											"properties": {
+												"jobs": {
+													"type": "object",
+													"additionalProperties": {
+														"properties": {
+															"steps": {
+																"type": "array",
+																"items": {
+																	"type": "object",
+																	"properties": {
+																		"uses": {
+																			"not": {
+																				"type": "string",
+																				"pattern": ".*actions\/setup-java@(v1).*"
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/rulesConfig/defaultRules/github/13-prevent-adopt-distributions-on-setup-java.json
+++ b/pkg/rulesConfig/defaultRules/github/13-prevent-adopt-distributions-on-setup-java.json
@@ -1,6 +1,6 @@
 {
 	"description": "Prevent use of adopt/adopt-hotspot distributions for actions/setup-java version 2+.",
-	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow.",
+	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow. Please, avoid the use of adopt/adopt-hotspot distributions since they are out of support. Use temurin based distributions instead (such distributions are currently maintained by the core adopt/adopt-hotspot team).",
 	"uniqueId": 13,
 	"enableByDefault": true,
 	"schema": {
@@ -27,11 +27,24 @@
 																"type": "array",
 																"items": {
 																	"type": "object",
-																	"properties": {
-																		"uses": {
-																			"not": {
+																	"if": {
+																		"properties": {
+																			"uses": {
 																				"type": "string",
-																				"pattern": ".*adopt(-hotspot)?"
+																				"pattern": ".*actions\/setup-java@(v2|v3).*"
+																			}
+																		},
+																		"required": [
+																			"uses"
+																		]
+																	},
+																	"then": {
+																		"properties": {
+																			"uses": {
+																				"not": {
+																					"type": "string",
+																					"pattern": ".*adopt(-hotspot)?"
+																				}
 																			}
 																		}
 																	}

--- a/pkg/rulesConfig/defaultRules/github/13-prevent-adopt-distributions-on-setup-java.json
+++ b/pkg/rulesConfig/defaultRules/github/13-prevent-adopt-distributions-on-setup-java.json
@@ -2,7 +2,7 @@
 	"description": "Prevent use of adopt/adopt-hotspot distributions for actions/setup-java version 2+.",
 	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow. Please, avoid the use of adopt/adopt-hotspot distributions since they are out of support. Use temurin based distributions instead (such distributions are currently maintained by the core adopt/adopt-hotspot team).",
 	"uniqueId": 13,
-	"enableByDefault": true,
+	"enabledByDefault": true,
 	"schema": {
 		"type": "object",
 		"additionalProperties": {
@@ -40,10 +40,15 @@
 																	},
 																	"then": {
 																		"properties": {
-																			"uses": {
-																				"not": {
-																					"type": "string",
-																					"pattern": ".*adopt(-hotspot)?"
+																			"with": {
+																				"type": "object",
+																				"properties": {
+																					"distribution": {
+																						"not": {
+																							"type": "string",
+																							"pattern": ".*adopt(-hotspot)?"
+																						}
+																					}
 																				}
 																			}
 																		}

--- a/pkg/rulesConfig/defaultRules/github/13-prevent-adopt-distributions-on-setup-java.json
+++ b/pkg/rulesConfig/defaultRules/github/13-prevent-adopt-distributions-on-setup-java.json
@@ -1,0 +1,54 @@
+{
+	"description": "Prevent use of adopt/adopt-hotspot distributions for actions/setup-java version 2+.",
+	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow.",
+	"uniqueId": 13,
+	"enableByDefault": true,
+	"schema": {
+		"type": "object",
+		"additionalProperties": {
+			"type": "object",
+			"properties": {
+				"repositories": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "object",
+						"properties": {
+							"github-actions-workflows": {
+								"type": "object",
+								"additionalProperties": {
+									"properties": {
+										"content": {
+											"properties": {
+												"jobs": {
+													"type": "object",
+													"additionalProperties": {
+														"properties": {
+															"steps": {
+																"type": "array",
+																"items": {
+																	"type": "object",
+																	"properties": {
+																		"uses": {
+																			"not": {
+																				"type": "string",
+																				"pattern": ".*adopt(-hotspot)?"
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/rulesConfig/defaultRules/gitlab/12-prevent-action-setup-java-v1.json
+++ b/pkg/rulesConfig/defaultRules/gitlab/12-prevent-action-setup-java-v1.json
@@ -1,0 +1,7 @@
+{
+	"description": "Prevent use of action/setup-java@v1.",
+	"failureMessage": "action/setup-java@v1 is used on the workflow.",
+	"uniqueId": 12,
+	"enableByDefault": true,
+	"schema": {} 
+}

--- a/pkg/rulesConfig/defaultRules/gitlab/12-prevent-action-setup-java-v1.json
+++ b/pkg/rulesConfig/defaultRules/gitlab/12-prevent-action-setup-java-v1.json
@@ -2,6 +2,6 @@
 	"description": "Prevent use of action/setup-java@v1.",
 	"failureMessage": "action/setup-java@v1 is used on the workflow. action/setup-java@v1 uses a java distribution that is out of support (AdoptOpenJDK) by default, please use action/setup-java@v2+ and avoid the use of adopt/adopt-host distributions.",
 	"uniqueId": 12,
-	"enableByDefault": true,
+	"enabledByDefault": true,
 	"schema": {} 
 }

--- a/pkg/rulesConfig/defaultRules/gitlab/12-prevent-action-setup-java-v1.json
+++ b/pkg/rulesConfig/defaultRules/gitlab/12-prevent-action-setup-java-v1.json
@@ -1,6 +1,6 @@
 {
 	"description": "Prevent use of action/setup-java@v1.",
-	"failureMessage": "action/setup-java@v1 is used on the workflow.",
+	"failureMessage": "action/setup-java@v1 is used on the workflow. action/setup-java@v1 uses a java distribution that is out of support (AdoptOpenJDK) by default, please use action/setup-java@v2+ and avoid the use of adopt/adopt-host distributions.",
 	"uniqueId": 12,
 	"enableByDefault": true,
 	"schema": {} 

--- a/pkg/rulesConfig/defaultRules/gitlab/13-prevent-adopt-distributions-on-setup-java.json
+++ b/pkg/rulesConfig/defaultRules/gitlab/13-prevent-adopt-distributions-on-setup-java.json
@@ -1,6 +1,6 @@
 {
 	"description": "Prevent use of adopt/adopt-hotspot distributions for actions/setup-java version 2+.",
-	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow.",
+	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow. Please, avoid the use of adopt/adopt-hotspot distributions since they are out of support. Use temurin based distributions instead (such distributions are currently maintained by the core adopt/adopt-hotspot team).",
 	"uniqueId": 13,
 	"enableByDefault": true,
 	"schema": {}

--- a/pkg/rulesConfig/defaultRules/gitlab/13-prevent-adopt-distributions-on-setup-java.json
+++ b/pkg/rulesConfig/defaultRules/gitlab/13-prevent-adopt-distributions-on-setup-java.json
@@ -1,0 +1,7 @@
+{
+	"description": "Prevent use of adopt/adopt-hotspot distributions for actions/setup-java version 2+.",
+	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow.",
+	"uniqueId": 13,
+	"enableByDefault": true,
+	"schema": {}
+}

--- a/pkg/rulesConfig/defaultRules/gitlab/13-prevent-adopt-distributions-on-setup-java.json
+++ b/pkg/rulesConfig/defaultRules/gitlab/13-prevent-adopt-distributions-on-setup-java.json
@@ -2,6 +2,6 @@
 	"description": "Prevent use of adopt/adopt-hotspot distributions for actions/setup-java version 2+.",
 	"failureMessage": "adopt/adopt-hotspot distribution is used on the workflow. Please, avoid the use of adopt/adopt-hotspot distributions since they are out of support. Use temurin based distributions instead (such distributions are currently maintained by the core adopt/adopt-hotspot team).",
 	"uniqueId": 13,
-	"enableByDefault": true,
+	"enabledByDefault": true,
 	"schema": {}
 }


### PR DESCRIPTION
# Solves #26
* Adds the `prevent-action-setup-java-v1` rule. It prevents the use of the action `setup-java@v1`, since it doesn't allow uses to specify the distribution they'll use.
* Adds the `prevent-adopt-distributions-on-setup-java` rule. It prevents the use of `adopt/adopt-hotspot` distributions since such distributions won't be supported anymore.