### PR TITLE
feat: add run configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,22 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        {
+            "name": "run",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/main.go",
+            "env": {},
+            "args": ["validate"],
+            "showLog": true
+        },
         {
             "name": "Fetch",
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "./main.go",
+            "program": "${workspaceFolder}/main.go",
             "env": {},
             "args": ["fetch", "github", "allero-io"],
         }


### PR DESCRIPTION
Since allero has 2 main flows, it will be easier to just have them both available, and switch between them instead of changing the args manually.

Signed-off-by: dolby360 <dolevben054@gmail.com>