### PR TITLE
add initial docker push workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,45 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         run: bash ./scripts/brew_push_formula.sh ${{ github.event.inputs.release_version }}
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and export to Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: true
+          tags:
+            - allero/allero-cli:${{ github.event.inputs.release_version }}
+            - latest
+      -
+        name: Test
+        run: |
+          docker run --rm allero/allero-cli:${{ github.event.inputs.release_version }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags:
+            - allero/allero-cli:${{ github.event.inputs.release_version }}
+            - latest


### PR DESCRIPTION
This adds a workflow to push images to dockerhub.

You need to create two variables in the repo for the username and token:
```
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_TOKEN }}
```

This pushes two tags: latest and the git-tag.

I couldn't test it but hope that it will mostly work and you can then iterate on it.