### PR TITLE
feat(terraform): add tfsec to terraform scanner rules

### DIFF
--- a/pkg/rulesConfig/defaultRules/11-ensure-terraform-scanner.go
+++ b/pkg/rulesConfig/defaultRules/11-ensure-terraform-scanner.go
@@ -7,6 +7,7 @@ import (
 	gitlabConnector "github.com/allero-io/allero/pkg/connectors/gitlab"
 )
 
+// EnsureTerraformScanner is a function which checks pipelines for the presence of a terraform scanner
 func EnsureTerraformScanner(githubData map[string]*githubConnector.GithubOwner, gitlabData map[string]*gitlabConnector.GitlabGroup) ([]*SchemaError, error) {
 	schemaErrors := make([]*SchemaError, 0)
 	var err error
@@ -36,12 +37,14 @@ func githubErrorsRule11(githubData map[string]*githubConnector.GithubOwner) ([]*
 		".*tenable/terrascan-action@.*",
 		".*snyk/actions/iac@.*",
 		".*aquasecurity/trivy-action@.*",
+		".*aquasecurity/tfsec-action@(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
 		".*checkmarx/kics-github-action@.*",
 		".*kubescape/github-action@.*",
 	}
 
 	runRegexExpressions := []string{
 		".*^[\\S]*trivy.*|.*docker .* run .*(aquasec/)?trivy.*",
+		".*^[\\S]*tfsec.*",
 		".*docker .* run .*checkmarx/kics scan.*",
 		".*kubescape scan.*",
 	}


### PR DESCRIPTION
This PR adds [AcquaSecurity TFSec](https://aquasecurity.github.io/tfsec) as one of the possible terraform scanners.
It checks for the presence of the [Github Action](https://github.com/marketplace/actions/tfsec-action) or the cli. The Github Action is expected to use a released version, using the [suggested regex for SemVer](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)

This is my first PR to the repo :) I've read the contributing guide and run a test locally, but will happily make any changes requested if the PR is incomplete so far.

Thanks,
Bruce

Signed-off-by: Bruce Becker <brucellino@protonmail.com>